### PR TITLE
[Sprint] feat: create user statistic record in DB when register

### DIFF
--- a/src/API/index.ts
+++ b/src/API/index.ts
@@ -340,7 +340,7 @@ function getFormattedErrorText(errorText: string): string {
 }
 
 // Create brand new statisic
-function createNewUserStatistic(): Statistic {
+export function createNewUserStatistic(): Statistic {
   const newStatistic: Statistic = {
     learnedWords: 0,
     optional: {

--- a/src/components/register-form/register-form.ts
+++ b/src/components/register-form/register-form.ts
@@ -1,5 +1,7 @@
 import * as auth from 'utils/auth';
-import { createUser, loginUser } from 'API/index';
+import {
+  createUser, loginUser, updateUserStatistic, createNewUserStatistic,
+} from 'API/index';
 import { AlertType } from 'types/index';
 import { outputAlert, outputResponseErrors, clearAlerts } from 'components/alert-message/alert-message';
 
@@ -18,7 +20,6 @@ function eventHandler(elem: HTMLElement): void {
 
     clearAlerts(elem);
 
-    // TODO: show spinner while creating user
     submitBtn.disabled = true;
     const creationResult = await createUser(name.value, email.value, password.value);
     submitBtn.disabled = false;
@@ -36,6 +37,7 @@ function eventHandler(elem: HTMLElement): void {
     }
 
     auth.saveAuth(loginResult);
+    updateUserStatistic(createNewUserStatistic());
     elem.dispatchEvent(new Event('authUpdate', { bubbles: true }));
   };
 }


### PR DESCRIPTION
В момент регистрации нового пользователя создавать запись в БД, хранящую его пользовательскую статистику.

До этого пользовательская статистика создавалась в момент первого обращения к ней. В этом случае в консоль попадало 404 сообщение от **fetch** (что было не очень красиво). Теперь этого не должно случаться.