### PR TITLE
[Sprint] feat: logout and reload if can't update token while authFetch

### DIFF
--- a/src/API/index.ts
+++ b/src/API/index.ts
@@ -1,4 +1,5 @@
 import * as auth from 'utils/auth';
+import * as state from 'utils/state';
 import {
   Endpoints, Word, User, ResponseError, Auth, StatusCode, UserWord,
   ResponseUserWord, AggregatedResults, Statistic, WordsStatistic, GameStatistic,
@@ -115,9 +116,10 @@ export async function updateToken(): Promise<void> {
 
   const response = await fetch(url, options);
 
-  // If can't get new token - logout and reload
+  // If can't get new token - logout and show login page after reload
   if (!response.ok) {
     auth.deleteAuth();
+    state.updateState('page', 'login');
     window.location.reload();
   }
 


### PR DESCRIPTION
Логаут пользователя и перезагрузка страницы на страницу **Login**-а, если не удается обновить просроченный токен.

Должно решить проблему, когда пользователь возвращался спустя длительное время (например через день) и пытался обратиться к серверу со старым **token**-ом и старым **refreshToken**-ом. Это приводило к выводу ошибок в консоли. 