### PR TITLE
[Sprint] feat: add wrong answers fields in the user statistic

### DIFF
--- a/src/API/index.ts
+++ b/src/API/index.ts
@@ -12,6 +12,7 @@ export const DEFAULT_WORDS_STAT: WordsStatistic = {
   learnedWordsQty: 0,
   newWordsQty: 0,
   rightAnswers: 0,
+  wrongAnswers: 0,
 };
 
 export const DEFAULT_GAME_STAT: GameStatistic = {
@@ -19,6 +20,7 @@ export const DEFAULT_GAME_STAT: GameStatistic = {
   longestRow: 0,
   newWordsQty: 0,
   rightAnswers: 0,
+  wrongAnswers: 0,
 };
 
 export async function getWords(group: number, page: number): Promise<Word[]> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -73,6 +73,7 @@ export interface GameStatistic {
   newWordsQty: number;
   longestRow: number;
   rightAnswers: number;
+  wrongAnswers: number;
 }
 
 export interface WordsStatistic {
@@ -80,6 +81,7 @@ export interface WordsStatistic {
   newWordsQty: number;
   learnedWordsQty: number;
   rightAnswers: number;
+  wrongAnswers: number;
 }
 
 export interface Word {


### PR DESCRIPTION
Добавил поле `wrongAnswers` (в дополнение к полю `rightAnswers`) в объекты **GameStatistic** и **WordsStatisitc**, чтобы можно было высчитывать процент правильных слов.