### PR TITLE
[Sprint] fix: prevent multiple loading of page content when multi-clicking

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -35,11 +35,13 @@ async function loadPage(): Promise<void> {
     [PageName.login]: () => Promise.resolve(getLoginPage()),
   };
 
-  const pageElement = await getPage[curPage]();
+  const fragment = new DocumentFragment();
+
+  fragment.append(getHeader());
+  fragment.append(await getPage[curPage]());
 
   document.body.innerHTML = '';
-  document.body.append(getHeader());
-  document.body.append(pageElement);
+  document.body.append(fragment);
 }
 
 function handleEvents(): void {


### PR DESCRIPTION
Переписал функцию загрузки страниц.

Решает проблему загрузки на страницу нескольких копий содержимого страниц. Баг проявлялся для страниц с асинхронным кодом. Если пользователь успевал сделать дополнительные клики в момент подготовки содержимого страницы, то загружалось столько копий, сколько он успел накликать.